### PR TITLE
Support .go-version file parsing

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -85,13 +85,7 @@ func projectRootPath() string {
 }
 
 func readGoVersion(path string) string {
-	f, err := os.Open(path + "/.go-version")
-	if err != nil {
-		return ""
-	}
-	defer f.Close()
-
-	b, err := ioutil.ReadAll(f)
+	b, err := ioutil.ReadFile(filepath.Join(path, ".go-version"))
 	if err != nil {
 		return ""
 	}
@@ -99,7 +93,7 @@ func readGoVersion(path string) string {
 }
 
 func removeNewLine(b []byte) []byte {
-	return b[:len(b)-1]
+	return bytes.TrimRight(b, "\n")
 }
 
 // execGo is execution Go command and os.Args[1:] will transfer.

--- a/go/main.go
+++ b/go/main.go
@@ -3,6 +3,7 @@ package main // import "go.nanasi880.dev/goenv/go"
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -67,6 +68,38 @@ func getenv(key string, def string) string {
 func loadEnv() {
 	installLocation = getenv("GOENV_LOCATION", "/usr/local/go/bin")
 	userInstructedGoCmd = os.Getenv("GOCMD")
+	if userInstructedGoCmd == "" {
+		p := projectRootPath()
+		if p != "" {
+			userInstructedGoCmd = readGoVersion(p)
+		}
+	}
+}
+
+func projectRootPath() string {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return string(removeNewLine(out))
+}
+
+func readGoVersion(path string) string {
+	f, err := os.Open(path + "/.go-version")
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return ""
+	}
+	return "go" + string(removeNewLine(b))
+}
+
+func removeNewLine(b []byte) []byte {
+	return b[:len(b)-1]
 }
 
 // execGo is execution Go command and os.Args[1:] will transfer.


### PR DESCRIPTION
Find executable go command from .go-version which placed on top directory
as long as when $GOCMD was not set.